### PR TITLE
Data Source for "DefaultConnection" changed from "localhost" to (localdb)\MSSQLLOCALDB

### DIFF
--- a/SampleWebApp/Web.config
+++ b/SampleWebApp/Web.config
@@ -9,7 +9,7 @@
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   </configSections>
   <connectionStrings>    
-    <add name="DefaultConnection" connectionString="Data Source=(localdb)\MSSQLLOCALDB;Database=PostulateWebDemo;Integrated Security=True" providerName="System.Data.SqlClient" />
+    <add name="DefaultConnection" connectionString="Data Source=(localdb)\MSSQLLOCALDB;Database=PostulateWebDemo;Integrated Security=SSPI" providerName="System.Data.SqlClient" />
   </connectionStrings>
   <appSettings>
     <add key="webpages:Version" value="3.0.0.0" />

--- a/SampleWebApp/Web.config
+++ b/SampleWebApp/Web.config
@@ -9,7 +9,7 @@
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   </configSections>
   <connectionStrings>    
-    <add name="DefaultConnection" connectionString="Data Source=localhost;Database=PostulateWebDemo;Integrated Security=SSPI" providerName="System.Data.SqlClient" />
+    <add name="DefaultConnection" connectionString="Data Source=(localdb)\MSSQLLOCALDB;Database=PostulateWebDemo;Integrated Security=True" providerName="System.Data.SqlClient" />
   </connectionStrings>
   <appSettings>
     <add key="webpages:Version" value="3.0.0.0" />


### PR DESCRIPTION
Assuming nobody will have an SQL Server instance running at "localhost", default connection string changed to (localdb)\MSSQLLOCALDB.